### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/MaxUlysse/conferenceCoverage.png?label=ready&title=Ready)](https://waffle.io/MaxUlysse/conferenceCoverage)
 # conferenceCoverage <img alt="conferenceCoverage Logo" src="http://i.imgur.com/TpCB7HW.png" height=50 /> 1.3.5
 
 ## ABOUT


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/MaxUlysse/conferenceCoverage

This was requested by a real person (user MaxUlysse) on waffle.io, we're not trying to spam you.
